### PR TITLE
Add UTop dependency - replaces default interface to OCaml toplevel

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -6,6 +6,7 @@ eval `opam config env`
 
 opam install merlin
 opam install ounit
+opam install utop
 
 echo 'WARNING: You must run this command before interacting with OCaml in this shell:'
 echo ''


### PR DESCRIPTION
Adds UTop dependency, which replaces the default interface to OCaml toplevel (and feels a lot like GHCI). More info can be found [here](https://opam.ocaml.org/blog/about-utop/).

Features that I know of:
* import/interpret OCaml source code
* list the functions in a module
* get the type of an expression

Video of the thingy in action:

[![asciicast](https://asciinema.org/a/OepioSFoxREwCEaMHyKUE8mhB.png)](https://asciinema.org/a/OepioSFoxREwCEaMHyKUE8mhB)