### PR TITLE
Improve perm tests to use set-like equality and check for deduplication.

### DIFF
--- a/a2/test.ml
+++ b/a2/test.ml
@@ -22,6 +22,9 @@ let data4 : Query.movie list = [
   ("Harry Potter and the Deathly Hallows Part 2","WB",381.01,2011)
 ]
 
+let assert_set_equal (a:'a list) (b:'a list) =
+  assert_equal (List.sort compare a) (List.sort compare b)
+
 let suite =
   "A2" >::: [
     "zardoz" >:: (fun _ -> 
@@ -51,17 +54,24 @@ let suite =
 
     "perm: 1" >:: (fun _ ->
         skip_if true "skip";
-        assert_equal (Part1.perm [1]) [[1;]] 
+        assert_set_equal (Part1.perm [1]) [[1;]] 
       );
 
     "perm: 2" >:: (fun _ -> 
         skip_if true "skip";
-        assert_equal (Part1.perm [1;2]) [[1;2]; [2;1]] 
+        assert_set_equal (Part1.perm [1;2]) [[1;2]; [2;1]] 
       );
 
     "perm: 3" >:: (fun _ -> 
         skip_if true "skip";
-        assert_equal (Part1.perm [1;2;3]) [[1;2;3]; [1;3;2]; [2;1;3]; [2;3;1]; [3;1;2]; [3;2;1]] 
+        assert_set_equal (Part1.perm [1;2;3]) [[1;2;3]; [1;3;2]; [2;1;3]; [2;3;1]; [3;1;2]; [3;2;1]] 
+      );
+
+    "perm: 4" >:: (fun _ ->
+        skip_if true "skip";
+        assert_set_equal (Part1.perm [1;2;2;3]) [[1; 2; 2; 3]; [1; 2; 3; 2]; [1; 3; 2; 2]; [2; 1; 2; 3];
+                                                 [2; 1; 3; 2]; [2; 2; 1; 3]; [2; 2; 3; 1]; [2; 3; 1; 2];
+                                                 [2; 3; 2; 1]; [3; 1; 2; 2]; [3; 2; 1; 2]; [3; 2; 2; 1]]
       );
 
     "average 1" >:: (fun _ -> 


### PR DESCRIPTION
The tests for `perm` need to use set-like equality, since order is unspecified.

Should also add a test for `perm []` -- but I didn't do that.

Also, importantly (in my opinion, and evidenced by the `~` when describing size of results), we need to test that permutations of lists containing duplicates do not contain duplicate permutations. I added a single test covering that case.