### PR TITLE
Test for stack overflow with large(r) permutation.

### DIFF
--- a/a2/Makefile
+++ b/a2/Makefile
@@ -10,15 +10,15 @@ check: boxoffice
 topG:  boxoffice
 	./boxoffice -sort-gross < data/G.txt | ./boxoffice -take 1
 
-part1.d.byte:  part1.ml
-	ocamlbuild part1.d.byte
+part1.d.native:  part1.ml
+	ocamlbuild part1.native
 
 clean:
 	ocamlbuild -clean
 
 test: build
-	-./test.d.byte
-	rm test.d.byte
+	-./test.native
+	rm test.native
 
 build: clean
-	ocamlbuild -use-ocamlfind -pkgs 'oUnit' test.d.byte
+	ocamlbuild -use-ocamlfind -pkgs 'oUnit' test.native

--- a/a2/test.ml
+++ b/a2/test.ml
@@ -74,6 +74,13 @@ let suite =
                                                  [2; 3; 2; 1]; [3; 1; 2; 2]; [3; 2; 1; 2]; [3; 2; 2; 1]]
       );
 
+    (* Bonus test -- note this may take a long time, and you will get a stack overflow if your implementation
+       grows the stack (i.e. is not tail recursive). *)
+    "perm: 5" >:: (fun _ ->
+        skip_if true "skip";
+        assert_equal (List.length (Part1.perm [1;2;3;4;5;6;7;8;9;10])) 3628800
+      );
+
     "average 1" >:: (fun _ -> 
         skip_if true "skip";
         assert_bool "bad average" (cmp_float ~epsilon:0.01 377.85 (Query.average data1) )


### PR DESCRIPTION
If perm is not tail-recursive, the stack will grow. In that case, I got a stack overflow at 10 items. To pass this test, implementations will have to avoid that and calculate the (I believe) correct size of the result.

In order to speed this up, generate native rather than byte code. For me, that brought the time down from ~15s to ~8s. I'm not certain my adjustments to the make file were fully consistent/correct, since I didn't study carefully. They do at least work for me, though.