### PR TITLE
A4 tests

### DIFF
--- a/a3/test.ml
+++ b/a3/test.ml
@@ -3,13 +3,13 @@ open OUnit2;;
 let test_find_zero_exact (exp:string) : unit =
   let e = ExpressionLibrary.parse exp in
   (* For some reason, cmp_float is failing here. Rather than debug too much, use this. *)
-  let my_cmp_float a b epsilon : bool = ((abs_float (a -. b)) < epsilon) in
+  let my_cmp_float epsilon a b : bool = ((abs_float (a -. b)) < epsilon) in
   match Expression.find_zero_exact e with
   | Some solution ->
     let s = (Expression.evaluate solution 123.) in
     let zero = (Expression.evaluate e s) in
 
-    assert_bool "not equal" (my_cmp_float zero 0. 0.001)
+    assert_equal ~cmp:(my_cmp_float 0.001) ~printer:string_of_float 0. zero
   | None -> assert false
 
 let suite =
@@ -71,19 +71,16 @@ let suite =
 
         let output = Expression.evaluate f' 2. in
 
-        Printf.printf "\nderivative: %f" output;
-        assert_equal output 4.
+        assert_equal ~printer:string_of_float 4. output
       );
 
     "find_zero: simple" >:: (fun _ -> 
         skip_if true "skip";
         let f = (ExpressionLibrary.parse "x * x - 1") in
-        let output = Expression.find_zero f 2. 0.01 50 in
 
-        match output with
+        match Expression.find_zero f 2. 0.01 50 with
         | Some x ->
-          (Printf.printf "\nfind_zero: Some %f" x);
-          assert_bool "not equal" (cmp_float ~epsilon:0.001 x 1.)
+          assert_equal ~cmp:(cmp_float ~epsilon:0.001) ~printer:string_of_float 1. x
         | None ->
           assert_failure "find_zero: None"
       );
@@ -114,7 +111,7 @@ let suite =
         test_find_zero_exact "5*x - 3 + 2*(x - 8)";
         test_find_zero_exact "5*x - 3 + 2*(x - 8) + 17*(3*x + 9)";
         test_find_zero_exact "(x * x * 0) + (x * 0.2) + 3";
-        );
+      );
   ]
 
 let () =

--- a/a4/Makefile
+++ b/a4/Makefile
@@ -5,3 +5,10 @@ testing: $(TESTFILES)
 
 clean:
 	ocamlbuild -clean
+
+test: build
+	-./test.d.byte
+	rm test.d.byte
+
+build: clean
+	ocamlbuild -use-ocamlfind -pkgs 'oUnit' test.d.byte

--- a/a4/test.ml
+++ b/a4/test.ml
@@ -1,0 +1,67 @@
+open OUnit2;;
+
+open Syntax
+open Printing
+open Testing 
+
+let eval (e: exp) : string =
+  e
+  |> EvalEnv.eval
+  |> string_of_exp
+
+let identity x = x
+let assert_eq_string = assert_equal ~printer:identity
+
+let suite =
+  "A4" >::: [
+    "zero" >:: (fun _ -> 
+        assert_eq_string (eval Testing.zero) "0";
+      );
+
+    "fact4" >:: (fun _ -> 
+        assert_eq_string (eval Testing.fact4) "24";
+      );
+
+    "list4" >:: (fun _ -> 
+        assert_eq_string (eval Testing.list4) "1::2::3::4::[]";
+      );
+
+    "sl4" >:: (fun _ -> 
+        assert_eq_string (eval Testing.sl4) "10";
+      );
+
+    "clo" >:: (fun _ -> 
+        assert_eq_string (eval Testing.clo) "11";
+      );
+
+    "incr_all: empty" >:: (fun _ -> 
+        let exp = App(incr_all, EmptyList) in
+
+        assert_eq_string (eval exp) "[]";
+      );
+
+    "incr_all" >:: (fun _ -> 
+        let list3 = listify [one;two;three] in
+        let exp = App(incr_all, list3) in
+
+        assert_eq_string (eval exp) "2::3::4::[]";
+      );
+
+    "sum_pairs: empty" >:: (fun _ -> 
+        let exp = App(sum_pairs, EmptyList) in
+
+        assert_eq_string (eval exp) "[]";
+      );
+
+    "sum_pairs" >:: (fun _ -> 
+        let pairs = 
+          Cons (Pair (one, two), Cons( Pair (three, four), EmptyList)) in
+        let exp = App(sum_pairs, pairs) in
+
+        assert_eq_string (eval exp) "3::7::[]";
+      );
+  ]
+
+let () =
+  run_test_tt_main suite
+;;


### PR DESCRIPTION
## Goals
Run the tests from a4/Testing.ml in oUnit, so it's easier to verify your answers

## Implementation
- Since test.ml is taking care of just checking the outputs, default Main.ml to using `debug_eval`, since test.ml isn't printing intermediate steps
- All the tests use `~printer:identity`, so they'll actually print diffs now
- Also I noticed I had some printer additions to a3 in a branch that I forgot to merge, so I figured I'd roll them up in here

## For discussion
- I think it might be easier on people writing additional tests if we drop the `skip if true` stuff, so we don't have merge conflicts flipping between master and our branches, so I left them out
- Feel free to add more tests